### PR TITLE
Fix Aer import and update CI

### DIFF
--- a/.github/workflows/qiskit-tests.yml
+++ b/.github/workflows/qiskit-tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        pip install qiskit numpy
+        pip install qiskit qiskit-aer numpy
 
     - name: Run Qiskit Tests
       run: |

--- a/Qiskit/hadamard_test.py
+++ b/Qiskit/hadamard_test.py
@@ -1,5 +1,6 @@
 
-from qiskit import QuantumCircuit, Aer, execute
+from qiskit import QuantumCircuit, execute
+from qiskit.providers.aer import Aer
 import numpy as np
 
 def test_hadamard_distribution():


### PR DESCRIPTION
## Summary
- update Hadamard test to import Aer from `qiskit.providers.aer`
- install `qiskit-aer` in the Qiskit workflow

## Testing
- `python Qiskit/hadamard_test.py` *(fails: ModuleNotFoundError: No module named 'qiskit')*

------
https://chatgpt.com/codex/tasks/task_e_68556400e4e083289b4be26e2a2f9d67