### PR TITLE
Add Bell state entanglement tests

### DIFF
--- a/.github/workflows/braket-tests.yml
+++ b/.github/workflows/braket-tests.yml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Run Braket Tests
       run: |
+        echo "------------Superposição---------------------------"
         python Braket/double_hadamard_test.py
+        echo "------------Emaranhamento Quântico---------------------------"
         python Braket/bell_state_test.py
 

--- a/.github/workflows/braket-tests.yml
+++ b/.github/workflows/braket-tests.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Run Braket Tests
       run: |
         python Braket/double_hadamard_test.py
-        exit $status
+        python Braket/bell_state_test.py
 

--- a/.github/workflows/cirq-tests.yml
+++ b/.github/workflows/cirq-tests.yml
@@ -27,5 +27,5 @@ jobs:
     - name: Run Cirq Tests
       run: |
         python Cirq/hadamard_test.py
-        exit $status
+        python Cirq/bell_state_test.py
 

--- a/.github/workflows/cirq-tests.yml
+++ b/.github/workflows/cirq-tests.yml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Run Cirq Tests
       run: |
+        echo "------------Superposição---------------------------"
         python Cirq/hadamard_test.py
+        echo "------------Emaranhamento Quântico---------------------------"
         python Cirq/bell_state_test.py
 

--- a/.github/workflows/pennylane-tests.yml
+++ b/.github/workflows/pennylane-tests.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Run PennyLane Tests
       run: |
         python PennyLane/hadamard_test.py
-        exit $status
+        python PennyLane/bell_state_test.py

--- a/.github/workflows/pennylane-tests.yml
+++ b/.github/workflows/pennylane-tests.yml
@@ -26,5 +26,7 @@ jobs:
 
     - name: Run PennyLane Tests
       run: |
+        echo "------------Superposição---------------------------"
         python PennyLane/hadamard_test.py
+        echo "------------Emaranhamento Quântico---------------------------"
         python PennyLane/bell_state_test.py

--- a/.github/workflows/qiskit-tests.yml
+++ b/.github/workflows/qiskit-tests.yml
@@ -26,5 +26,7 @@ jobs:
 
     - name: Run Qiskit Tests
       run: |
+        echo "------------Superposição---------------------------"
         python Qiskit/hadamard_test.py
+        echo "------------Emaranhamento Quântico---------------------------"
         python Qiskit/bell_state_test.py

--- a/.github/workflows/qiskit-tests.yml
+++ b/.github/workflows/qiskit-tests.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Run Qiskit Tests
       run: |
         python Qiskit/hadamard_test.py
-        exit $status
+        python Qiskit/bell_state_test.py

--- a/Braket/bell_state_test.py
+++ b/Braket/bell_state_test.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 def test_bell_state_entanglement():
     logger.info("Criando circuito Bell")
-    circuit = Circuit().h(0).cnot(0, 1).measure(0, 1)
+    circuit = Circuit().h(0).cnot(0, 1).measure(0).measure(1)
     logger.info("Circuito criado:\n%s", circuit)
     simulator = LocalSimulator()
 

--- a/Braket/bell_state_test.py
+++ b/Braket/bell_state_test.py
@@ -1,0 +1,36 @@
+import logging
+from braket.circuits import Circuit
+from braket.devices import LocalSimulator
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def test_bell_state_entanglement():
+    logger.info("Criando circuito Bell")
+    circuit = Circuit().h(0).cnot(0, 1).measure(0, 1)
+    logger.info("Circuito criado:\n%s", circuit)
+    simulator = LocalSimulator()
+
+    result = simulator.run(circuit, shots=1000).result()
+    counts = result.measurement_counts
+    logger.info("Contagem: %s", counts)
+
+    total = sum(counts.values())
+    assert counts.get('00', 0) + counts.get('11', 0) == total, "Resultado deve ser apenas 00 ou 11"
+
+    zero_zero_ratio = counts.get('00', 0) / total
+    one_one_ratio = counts.get('11', 0) / total
+
+    assert abs(zero_zero_ratio - 0.5) < 0.05, "probabilidade de 00 próxima a 0.5"
+    assert abs(one_one_ratio - 0.5) < 0.05, "probabilidade de 11 próxima a 0.5"
+
+
+if __name__ == "__main__":
+    try:
+        test_bell_state_entanglement()
+    except AssertionError as exc:
+        logger.error("Testes falharam: %s", exc)
+        raise
+    else:
+        logger.info("Testes passaram: estado Bell criado corretamente")

--- a/Cirq/bell_state_test.py
+++ b/Cirq/bell_state_test.py
@@ -1,0 +1,42 @@
+import logging
+import cirq
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def test_bell_state_entanglement():
+    logger.info("Preparando circuito Bell")
+    q0, q1 = cirq.LineQubit.range(2)
+    circuit = cirq.Circuit(
+        cirq.H(q0),
+        cirq.CNOT(q0, q1),
+        cirq.measure(q0, q1, key='m')
+    )
+    logger.info("Circuito:\n%s", circuit)
+
+    logger.info("Rodando no Simulador Cirq")
+    simulator = cirq.Simulator()
+    result = simulator.run(circuit, repetitions=1000)
+    counts = result.histogram(key='m', fold_func=lambda bits: ''.join(str(b) for b in bits))
+
+    logger.info("Contagem: %s", counts)
+    total = sum(counts.values())
+    assert counts.get('00', 0) + counts.get('11', 0) == total, "Resultado deve ser apenas 00 ou 11"
+
+    zero_zero_ratio = counts.get('00', 0) / total
+    one_one_ratio = counts.get('11', 0) / total
+
+    assert np.isclose(zero_zero_ratio, 0.5, atol=0.05), "probabilidade de 00 próxima a 0.5"
+    assert np.isclose(one_one_ratio, 0.5, atol=0.05), "probabilidade de 11 próxima a 0.5"
+
+
+if __name__ == "__main__":
+    try:
+        test_bell_state_entanglement()
+    except AssertionError as exc:
+        logger.error("Testes falharam: %s", exc)
+        raise
+    else:
+        logger.info("Testes passaram: estado Bell criado corretamente")

--- a/PennyLane/bell_state_test.py
+++ b/PennyLane/bell_state_test.py
@@ -1,0 +1,45 @@
+import logging
+import pennylane as qml
+from pennylane import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+dev = qml.device("default.qubit", wires=2, shots=1000)
+
+@qml.qnode(dev)
+def circuit():
+    qml.Hadamard(wires=0)
+    qml.CNOT(wires=[0, 1])
+    return qml.sample(qml.PauliZ(0)), qml.sample(qml.PauliZ(1))
+
+def test_bell_state_entanglement():
+    logger.info("Rodando circuito PennyLane Bell")
+    logger.info("Circuito:\n%s", qml.draw(circuit)())
+    samples0, samples1 = circuit()
+    bits0 = (1 - samples0) / 2
+    bits1 = (1 - samples1) / 2
+    counts = {}
+    for b0, b1 in zip(bits0, bits1):
+        key = f"{int(b0)}{int(b1)}"
+        counts[key] = counts.get(key, 0) + 1
+
+    logger.info("Contagem: %s", counts)
+    total = sum(counts.values())
+    assert counts.get('00', 0) + counts.get('11', 0) == total, "Resultado deve ser apenas 00 ou 11"
+
+    zero_zero_ratio = counts.get('00', 0) / total
+    one_one_ratio = counts.get('11', 0) / total
+
+    assert np.isclose(zero_zero_ratio, 0.5, atol=0.05), "probabilidade de 00 próxima a 0.5"
+    assert np.isclose(one_one_ratio, 0.5, atol=0.05), "probabilidade de 11 próxima a 0.5"
+
+
+if __name__ == "__main__":
+    try:
+        test_bell_state_entanglement()
+    except AssertionError as exc:
+        logger.error("Testes falharam: %s", exc)
+        raise
+    else:
+        logger.info("Testes passaram: estado Bell criado corretamente")

--- a/Qiskit/bell_state_test.py
+++ b/Qiskit/bell_state_test.py
@@ -1,0 +1,48 @@
+try:
+    from qiskit import QuantumCircuit, transpile
+    from qiskit_aer import AerSimulator
+except ImportError as exc:
+    raise ImportError(
+        "Qiskit and qiskit-aer are required to run this test. Install with `pip install qiskit qiskit-aer`."
+    ) from exc
+
+import logging
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def test_bell_state_entanglement():
+    logger.info("Criando circuito Bell")
+    qc = QuantumCircuit(2, 2)
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.measure([0, 1], [0, 1])
+    logger.info("Circuito:\n%s", qc.draw(output='text'))
+
+    logger.info("Rodando no AerSimulator")
+    backend = AerSimulator()
+    compiled = transpile(qc, backend)
+    job = backend.run(compiled, shots=1000)
+    counts = job.result().get_counts()
+
+    logger.info("Contagem: %s", counts)
+    total = sum(counts.values())
+    assert counts.get('00', 0) + counts.get('11', 0) == total, "Resultado deve ser apenas 00 ou 11"
+
+    zero_zero_ratio = counts.get('00', 0) / total
+    one_one_ratio = counts.get('11', 0) / total
+
+    assert np.isclose(zero_zero_ratio, 0.5, atol=0.05), "probabilidade de 00 próxima a 0.5"
+    assert np.isclose(one_one_ratio, 0.5, atol=0.05), "probabilidade de 11 próxima a 0.5"
+
+
+if __name__ == "__main__":
+    try:
+        test_bell_state_entanglement()
+    except AssertionError as exc:
+        logger.error("Testes falharam: %s", exc)
+        raise
+    else:
+        logger.info("Testes passaram: estado Bell criado corretamente")


### PR DESCRIPTION
## Summary
- add tests across all frameworks for Bell state entanglement

## Testing
- `python Qiskit/bell_state_test.py` *(fails: No module named 'qiskit')*
- `python Cirq/bell_state_test.py` *(fails: No module named 'cirq')*
- `python PennyLane/bell_state_test.py` *(fails: No module named 'pennylane')*
- `python Braket/bell_state_test.py` *(fails: No module named 'braket')*

------
https://chatgpt.com/codex/tasks/task_e_6855976b230c83288193dd38058f2c3c